### PR TITLE
Replace dependency for deprecated workflow-cps-global-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+.vscode/
+*.iml
+.DS_Store
+target/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(jenkinsVersions: [null, '2.115'], platforms: ['linux'])
+buildPlugin(configurations: [
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.8</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
     <groupId>com.fuzzpro.jenkins-plugins</groupId>
@@ -16,7 +16,7 @@
     <description>Tear down infrastructure on branch deletion</description>
     <scm>
         <developerConnection>scm:git:git@github.com:jenkinsci/multibranch-job-tear-down-plugin.git</developerConnection>
-        <connection>scm:git:git://github.com/jenkinsci/multibranch-job-tear-down-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/multibranch-job-tear-down-plugin.git</connection>
         <url>https://github.com/jenkinsci/multibranch-job-tear-down-plugin</url>
       <tag>HEAD</tag>
   </scm>
@@ -39,56 +39,57 @@
     </contributors>
 
     <properties>
-        <jenkins.version>2.115</jenkins.version>
         <java.level>8</java.level>
-        <git.version>3.6.0</git.version>
-        <multibranch.version>2.20</multibranch.version>
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <git.version>5.2.1</git.version>
+        <multibranch.version>756.v891d88f2cd46</multibranch.version>
+        <pipeline-groovy-lib.version>656.va_a_ceeb_6ffb_f7</pipeline-groovy-lib.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3850.vb_c5319efa_e29</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>pipeline-groovy-lib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>${multibranch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.5</version>
+            <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>credentials</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps-global-lib</artifactId>
-            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.2.6</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -101,7 +102,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,11 +114,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownConfiguration.java
+++ b/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownConfiguration.java
@@ -24,12 +24,13 @@
 
 package com.fuzzpro.multibranchteardown;
 
+import java.io.Serializable;
+
 import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-import java.io.Serializable;
 
 @Extension
 public class JobTearDownConfiguration extends GlobalConfiguration implements Serializable {

--- a/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownListener.java
+++ b/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownListener.java
@@ -24,7 +24,11 @@
 
 package com.fuzzpro.multibranchteardown;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Cause;
@@ -35,7 +39,6 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
-import hudson.model.TopLevelItem;
 import hudson.model.listeners.ItemListener;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
@@ -47,19 +50,12 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.logging.Logger;
 
 @Extension
 public class JobTearDownListener extends ItemListener {
@@ -67,7 +63,16 @@ public class JobTearDownListener extends ItemListener {
     static final String LOGGER = JobTearDownListener.class.getSimpleName();
 
     @Override
+    public void onDeleted(Item item) {
+        processDeleted(item);
+    }
+
+    @Override
     public void onUpdated(Item item) {
+        processDeleted(item);
+    }
+
+    public void processDeleted(Item item) {
         Logger.getLogger(LOGGER).fine("Job Class: " + item.getClass().getSimpleName());
         if (canTearDownInfrastructure(item)) {
             Job job = (Job) item;
@@ -100,7 +105,7 @@ public class JobTearDownListener extends ItemListener {
             JobTearDownProperty jtdprop = (JobTearDownProperty) prop;
             Logger.getLogger(LOGGER).fine("Execute tear down on: " + jtdprop.getJobName());
             tearDownJob = Jenkins.get().getItemByFullName(jtdprop.getJobName());
-        }else if (jobName != null && !jobName.trim().isEmpty()) {
+        } else if (jobName != null && !jobName.trim().isEmpty()) {
             Logger.getLogger(LOGGER).fine("Default Job: " + config.getTearDownJob());
             tearDownJob = Jenkins.get().getItemByFullName(jobName);
         } else {
@@ -142,8 +147,8 @@ public class JobTearDownListener extends ItemListener {
         if (item instanceof WorkflowJob) {
             WorkflowJob job = (WorkflowJob) item;
             scms.addAll(job.getSCMs());
-        } else if(item instanceof AbstractProject) {
-            scms.add(((AbstractProject)item).getScm());
+        } else if (item instanceof AbstractProject) {
+            scms.add(((AbstractProject) item).getScm());
         }
 
         ArrayList<String> remoteURLs = new ArrayList<>();

--- a/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownProperty.java
+++ b/src/main/java/com/fuzzpro/multibranchteardown/JobTearDownProperty.java
@@ -24,17 +24,14 @@
 
 package com.fuzzpro.multibranchteardown;
 
+import java.io.Serializable;
+
 import hudson.Extension;
-import hudson.model.Descriptor;
-import hudson.model.DescriptorVisibilityFilter;
-import hudson.model.Job;
-import jenkins.branch.MultiBranchProject;
 import jenkins.model.OptionalJobProperty;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
-import java.io.Serializable;
 
 public class JobTearDownProperty extends OptionalJobProperty<WorkflowJob> implements Serializable {
 

--- a/src/test/java/com/fuzzpro/multibranchteardown/JobTearDownListenerTest.java
+++ b/src/test/java/com/fuzzpro/multibranchteardown/JobTearDownListenerTest.java
@@ -1,6 +1,8 @@
 package com.fuzzpro.multibranchteardown;
 
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import java.util.Arrays;
+import java.util.List;
+
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import jenkins.branch.BranchProperty;
@@ -8,6 +10,7 @@ import jenkins.branch.BranchSource;
 import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import org.htmlunit.html.HtmlForm;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -20,9 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+
 import static org.junit.Assert.fail;
 
 public class JobTearDownListenerTest {


### PR DESCRIPTION
Replace deprecated `workflow-cps-global-lib` by the new `pipeline-groovy-lib`

Close #3 

### Testing done

Tested successfuly on  Jenkins 2.493