### PR TITLE
Upgrade build platform to baseline 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(jenkinsVersions: [null, '2.115'], platforms: ['linux'])
+buildPlugin(configurations: [
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
+])
+


### PR DESCRIPTION
### Overview

To prepare the next iteration, with need to upgrade the build configuration to match with Java 17 baseline. 